### PR TITLE
Support for maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 vars-to-credhub*
+Gopkg.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 vendor/
 vars-to-credhub*
-Gopkg.lock

--- a/fixtures/input.yml
+++ b/fixtures/input.yml
@@ -7,3 +7,25 @@ ml-test: |
 someint: 3
 somefloat: 2.45
 somebool: false
+my_cert:
+  certificate: |
+    -----BEGIN CERTIFICATE----
+    fake cert
+    -----END CERTIFICATE----
+  ca: |
+    -----BEGIN CERTIFICATE----
+    also fake
+    -----END CERTIFICATE----
+  private_key: |
+    -----BEGIN FAKE RSA PRIVATE KEY----
+    fake key
+    -----END FAKE RSA PRIVATE KEY----
+uaa-key:
+  private_key: |
+    -----BEGIN FAKE RSA PRIVATE KEY-----
+    fake key is fake
+    -----END FAKE RSA PRIVATE KEY----
+  public_key: |
+    -----BEGIN PUBLIC KEY-----
+    fake public
+    -----END PUBLIC KEY-----

--- a/fixtures/output.yml
+++ b/fixtures/output.yml
@@ -20,3 +20,29 @@ credentials:
 - type: value
   name: somebool
   value: "false"
+- name: my_cert
+  type: certificate
+  value:
+    ca: |
+      -----BEGIN CERTIFICATE----
+      also fake
+      -----END CERTIFICATE----
+    certificate: |
+      -----BEGIN CERTIFICATE----
+      fake cert relax
+      -----END CERTIFICATE----
+    private_key: |
+      -----BEGIN FAKE RSA PRIVATE KEY----
+      fake key
+      -----END FAKE RSA PRIVATE KEY----
+- name: uaa-key
+  type: rsa
+  value:
+    private_key: |
+      -----BEGIN FAKE RSA PRIVATE KEY-----
+      fake key is fake
+      -----END FAKE RSA PRIVATE KEY----
+    public_key: |
+      -----BEGIN PUBLIC KEY-----
+      fake public
+      -----END PUBLIC KEY-----

--- a/main.go
+++ b/main.go
@@ -1,40 +1,40 @@
 package main
 
 import (
-    "bytes"
-    "fmt"
-    "log"
-    "os"
-    "strings"
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"strings"
 
-    "github.com/mitchellh/colorstring"
+	"github.com/mitchellh/colorstring"
 
-    "golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/crypto/ssh/terminal"
 
-    "gopkg.in/alecthomas/kingpin.v2"
-    "gopkg.in/yaml.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var (
-    varPrefix = kingpin.Flag("prefix", "credhub path prefix for vars").Short('p').Default("/concourse/main").String()
-    inputFile = kingpin.Flag("vars-file", "Pipeline vars file").Short('f').Required().File()
+	varPrefix = kingpin.Flag("prefix", "credhub path prefix for vars").Short('p').Default("/concourse/main").String()
+	inputFile = kingpin.Flag("vars-file", "Pipeline vars file").Short('f').Required().File()
 )
 
 func main() {
-    kingpin.Parse()
+	kingpin.Parse()
 
-    var b bytes.Buffer
-    encoder := yaml.NewEncoder(&b)
+	var b bytes.Buffer
+	encoder := yaml.NewEncoder(&b)
 
-    if bulkImport, err := Transform(*varPrefix, *inputFile); err != nil {
-        log.Fatal(err)
-    } else {
-        encoder.Encode(bulkImport)
-        outStr := b.String()
-        fmt.Println(strings.Replace(outStr, "subMapValue", "value", -1))
-        // taken from https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
-        if terminal.IsTerminal(int(os.Stdout.Fd())) {
-            colorstring.Println("[bold][green]Done! Double check these results, then save and run [reset]credhub import --file /path/to/file")
-        }
-    }
+	if bulkImport, err := Transform(*varPrefix, *inputFile); err != nil {
+		log.Fatal(err)
+	} else {
+		encoder.Encode(bulkImport)
+		outStr := b.String()
+		fmt.Println(strings.Replace(outStr, "subMapValue", "value", -1))
+		// taken from https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
+		if terminal.IsTerminal(int(os.Stdout.Fd())) {
+			colorstring.Println("[bold][green]Done! Double check these results, then save and run [reset]credhub import --file /path/to/file")
+		}
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,34 +1,40 @@
 package main
 
 import (
-	"log"
-	"os"
+    "bytes"
+    "fmt"
+    "log"
+    "os"
+    "strings"
 
-	"github.com/mitchellh/colorstring"
+    "github.com/mitchellh/colorstring"
 
-	"golang.org/x/crypto/ssh/terminal"
+    "golang.org/x/crypto/ssh/terminal"
 
-	"gopkg.in/alecthomas/kingpin.v2"
-	"gopkg.in/yaml.v2"
+    "gopkg.in/alecthomas/kingpin.v2"
+    "gopkg.in/yaml.v2"
 )
 
 var (
-	varPrefix = kingpin.Flag("prefix", "credhub path prefix for vars").Short('p').Default("/concourse/main").String()
-	inputFile = kingpin.Flag("vars-file", "Pipeline vars file").Short('f').Required().File()
+    varPrefix = kingpin.Flag("prefix", "credhub path prefix for vars").Short('p').Default("/concourse/main").String()
+    inputFile = kingpin.Flag("vars-file", "Pipeline vars file").Short('f').Required().File()
 )
 
 func main() {
-	kingpin.Parse()
+    kingpin.Parse()
 
-	encoder := yaml.NewEncoder(os.Stdout)
+    var b bytes.Buffer
+    encoder := yaml.NewEncoder(&b)
 
-	if bulkImport, err := Transform(*varPrefix, *inputFile); err != nil {
-		log.Fatal(err)
-	} else {
-		encoder.Encode(bulkImport)
-		// taken from https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
-		if terminal.IsTerminal(int(os.Stdout.Fd())) {
-			colorstring.Println("[bold][green]Done! Save this file and run [reset]credhub bulk-import --file /path/to/file")
-		}
-	}
+    if bulkImport, err := Transform(*varPrefix, *inputFile); err != nil {
+        log.Fatal(err)
+    } else {
+        encoder.Encode(bulkImport)
+        outStr := b.String()
+        fmt.Println(strings.Replace(outStr, "subMapValue", "value", -1))
+        // taken from https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go
+        if terminal.IsTerminal(int(os.Stdout.Fd())) {
+            colorstring.Println("[bold][green]Done! Double check these results, then save and run [reset]credhub import --file /path/to/file")
+        }
+    }
 }

--- a/transformer.go
+++ b/transformer.go
@@ -1,91 +1,91 @@
 package main
 
 import (
-    "fmt"
-    "io"
-    "strings"
+	"fmt"
+	"io"
+	"strings"
 
-    "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Importable represents a credential to be loaded into Credhub via `bulk-import`
 type Importable struct {
-    Name   string `yaml:"name"`
-    Type   string `yaml:"type"`
-    Value  string `yaml:"value,omitempty"`
-    SubMap map[interface{}]interface{} `yaml:"subMapValue,omitempty"`
+	Name   string                      `yaml:"name"`
+	Type   string                      `yaml:"type"`
+	Value  string                      `yaml:"value,omitempty"`
+	SubMap map[interface{}]interface{} `yaml:"subMapValue,omitempty"`
 }
 
 // BulkImport represents what will be actually sent to Credhub
 type BulkImport struct {
-    Credentials []Importable `yaml:"credentials"`
+	Credentials []Importable `yaml:"credentials"`
 }
 
 // Utility to test if something is a map
 func isMap(x interface{}) bool {
-    t := fmt.Sprintf("%T", x)
-    return strings.HasPrefix(t, "map[")
+	t := fmt.Sprintf("%T", x)
+	return strings.HasPrefix(t, "map[")
 }
 
 func handleMap(mapVal map[interface{}]interface{}, prefix string, parentKey string) Importable {
-    //RSA key types if output from bosh will have a fingerprint that credhub
-    //can't deal with, so we'll just remove it. Delete is harmless if the
-    //key DNE - so just do it on every map.
-    delete(mapVal, "public_key_fingerprint")
-    return Importable{
-        Name: fmt.Sprintf("%s/%s", prefix, parentKey),
-        Type: getType(parentKey, fmt.Sprint(mapVal)),
-        SubMap: mapVal,
-    }
+	//RSA key types if output from bosh will have a fingerprint that credhub
+	//can't deal with, so we'll just remove it. Delete is harmless if the
+	//key DNE - so just do it on every map.
+	delete(mapVal, "public_key_fingerprint")
+	return Importable{
+		Name:   fmt.Sprintf("%s/%s", prefix, parentKey),
+		Type:   getType(parentKey, fmt.Sprint(mapVal)),
+		SubMap: mapVal,
+	}
 }
 
 func getType(key string, valStr string) string {
-    //attempt to guess the type for the item, default to "value"
-    if strings.Contains(key, "password") || strings.Contains(key, "secret") {
-        return "password"
-    //the cert check should be above rsa since a cert may also contain a pk
-    } else if strings.Contains(valStr, "CERTIFICATE") {
-        return "certificate"
-    } else if strings.Contains(valStr, "KEY---") {
-        return "rsa"
-    }
-    return "value"
+	//attempt to guess the type for the item, default to "value"
+	if strings.Contains(key, "password") || strings.Contains(key, "secret") {
+		return "password"
+		//the cert check should be above rsa since a cert may also contain a pk
+	} else if strings.Contains(valStr, "CERTIFICATE") {
+		return "certificate"
+	} else if strings.Contains(valStr, "KEY---") {
+		return "rsa"
+	}
+	return "value"
 }
 
 func makeImportable(prefix string, key string, valStr string) Importable {
-    return Importable{
-        Name:  fmt.Sprintf("%s/%s", prefix, key),
-        Type:  getType(key, valStr),
-        Value: valStr,
-    }
+	return Importable{
+		Name:  fmt.Sprintf("%s/%s", prefix, key),
+		Type:  getType(key, valStr),
+		Value: valStr,
+	}
 }
 
 // Transform performs the translation from vars file to import file
 func Transform(prefix string, input io.Reader) (BulkImport, error) {
-    decoder := yaml.NewDecoder(input)
+	decoder := yaml.NewDecoder(input)
 
-    var pipelineVars map[interface{}]interface{}
-    decoder.Decode(&pipelineVars)
+	var pipelineVars map[interface{}]interface{}
+	decoder.Decode(&pipelineVars)
 
-    vals := make([]Importable, 0, len(pipelineVars))
-    for key, val := range pipelineVars {
+	vals := make([]Importable, 0, len(pipelineVars))
+	for key, val := range pipelineVars {
 
-        // Let's require, for now, simple types & maps in the var field
-        var valStr string
-        switch v := val.(type) {
-        default:
-            if isMap(val) {
-                vals = append(vals, handleMap(val.(map[interface{}]interface{}), prefix, key.(string)))
-            } else {
-                return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values & maps are supported", v)
-            }
-        case bool, float32, float64, int, int16, int32, int64, string, uint, uint16, uint32, uint64:
-            valStr = fmt.Sprint(val)
-            vals = append(vals, makeImportable(prefix, key.(string), valStr))
-        }
-    }
+		// Let's require, for now, simple types & maps in the var field
+		var valStr string
+		switch v := val.(type) {
+		default:
+			if isMap(val) {
+				vals = append(vals, handleMap(val.(map[interface{}]interface{}), prefix, key.(string)))
+			} else {
+				return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values & maps are supported", v)
+			}
+		case bool, float32, float64, int, int16, int32, int64, string, uint, uint16, uint32, uint64:
+			valStr = fmt.Sprint(val)
+			vals = append(vals, makeImportable(prefix, key.(string), valStr))
+		}
+	}
 
-    return BulkImport{
-        Credentials: vals,
-    }, nil
+	return BulkImport{
+		Credentials: vals,
+	}, nil
 }

--- a/transformer.go
+++ b/transformer.go
@@ -39,8 +39,6 @@ func getType(key string, valStr string) string {
     //attempt to guess the type for the item, default to "value"
     if strings.Contains(key, "password") || strings.Contains(key, "secret") {
         return "password"
-    } else if strings.Contains(key, "user") || strings.Contains(key, "login") {
-        return "user"
     //the cert check should be above rsa since a cert may also contain a pk
     } else if strings.Contains(valStr, "CERTIFICATE") {
         return "certificate"

--- a/transformer.go
+++ b/transformer.go
@@ -1,51 +1,89 @@
 package main
 
 import (
-	"fmt"
-	"io"
+    "fmt"
+    "io"
+    "strings"
 
-	"gopkg.in/yaml.v2"
+    "gopkg.in/yaml.v2"
 )
 
 // Importable represents a credential to be loaded into Credhub via `bulk-import`
 type Importable struct {
-	Name  string `yaml:"name"`
-	Type  string `yaml:"type"`
-	Value string `yaml:"value"`
+    Name   string `yaml:"name"`
+    Type   string `yaml:"type"`
+    Value  string `yaml:"value,omitempty"`
+    SubMap map[interface{}]interface{} `yaml:"subMapValue,omitempty"`
 }
 
 // BulkImport represents what will be actually sent to Credhub
 type BulkImport struct {
-	Credentials []Importable `yaml:"credentials"`
+    Credentials []Importable `yaml:"credentials"`
+}
+
+// Utility to test if something is a map
+func isMap(x interface{}) bool {
+    t := fmt.Sprintf("%T", x)
+    return strings.HasPrefix(t, "map[")
+}
+
+func handleMap(mapVal map[interface{}]interface{}, prefix string, parentKey string) Importable {
+    return Importable{
+        Name: fmt.Sprintf("%s/%s", prefix, parentKey),
+        Type: getType(parentKey, fmt.Sprint(mapVal)),
+        SubMap: mapVal,
+    }
+}
+
+func getType(key string, valStr string) string {
+    //attempt to guess the type for the item, default to "value"
+    if strings.Contains(key, "password") || strings.Contains(key, "secret") {
+        return "password"
+    } else if strings.Contains(key, "user") || strings.Contains(key, "login") {
+        return "user"
+    //the cert check should be above rsa since a cert may also contain a pk
+    } else if strings.Contains(valStr, "CERTIFICATE") {
+        return "certificate"
+    } else if strings.Contains(valStr, "KEY---") {
+        return "rsa"
+    }
+    return "value"
+}
+
+func makeImportable(prefix string, key string, valStr string) Importable {
+    return Importable{
+        Name:  fmt.Sprintf("%s/%s", prefix, key),
+        Type:  getType(key, valStr),
+        Value: valStr,
+    }
 }
 
 // Transform performs the translation from vars file to import file
 func Transform(prefix string, input io.Reader) (BulkImport, error) {
-	decoder := yaml.NewDecoder(input)
+    decoder := yaml.NewDecoder(input)
 
-	var pipelineVars map[interface{}]interface{}
-	decoder.Decode(&pipelineVars)
+    var pipelineVars map[interface{}]interface{}
+    decoder.Decode(&pipelineVars)
 
-	vals := make([]Importable, 0, len(pipelineVars))
-	for key, val := range pipelineVars {
+    vals := make([]Importable, 0, len(pipelineVars))
+    for key, val := range pipelineVars {
 
-		// Let's require, for now, simple types only in the var field
-		var valStr string
-		switch v := val.(type) {
-		default:
-			return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values are supported", v)
-		case bool, float32, float64, int, int16, int32, int64, string, uint, uint16, uint32, uint64:
-			valStr = fmt.Sprint(val)
-		}
+        // Let's require, for now, simple types only in the var field
+        var valStr string
+        switch v := val.(type) {
+        default:
+            if isMap(val) {
+                vals = append(vals, handleMap(val.(map[interface{}]interface{}), prefix, key.(string)))
+            } else {
+                return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values are supported", v)
+            }
+        case bool, float32, float64, int, int16, int32, int64, string, uint, uint16, uint32, uint64:
+            valStr = fmt.Sprint(val)
+            vals = append(vals, makeImportable(prefix, key.(string), valStr))
+        }
+    }
 
-		vals = append(vals, Importable{
-			Name:  fmt.Sprintf("%s/%s", prefix, key),
-			Type:  "value",
-			Value: valStr,
-		})
-	}
-
-	return BulkImport{
-		Credentials: vals,
-	}, nil
+    return BulkImport{
+        Credentials: vals,
+    }, nil
 }

--- a/transformer.go
+++ b/transformer.go
@@ -28,6 +28,10 @@ func isMap(x interface{}) bool {
 }
 
 func handleMap(mapVal map[interface{}]interface{}, prefix string, parentKey string) Importable {
+    //RSA key types if output from bosh will have a fingerprint that credhub
+    //can't deal with, so we'll just remove it. Delete is harmless if the
+    //key DNE - so just do it on every map.
+    delete(mapVal, "public_key_fingerprint")
     return Importable{
         Name: fmt.Sprintf("%s/%s", prefix, parentKey),
         Type: getType(parentKey, fmt.Sprint(mapVal)),

--- a/transformer.go
+++ b/transformer.go
@@ -70,14 +70,14 @@ func Transform(prefix string, input io.Reader) (BulkImport, error) {
     vals := make([]Importable, 0, len(pipelineVars))
     for key, val := range pipelineVars {
 
-        // Let's require, for now, simple types only in the var field
+        // Let's require, for now, simple types & maps in the var field
         var valStr string
         switch v := val.(type) {
         default:
             if isMap(val) {
                 vals = append(vals, handleMap(val.(map[interface{}]interface{}), prefix, key.(string)))
             } else {
-                return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values are supported", v)
+                return BulkImport{}, fmt.Errorf("Invalid value type in vars file %T. Currently only primitive values & maps are supported", v)
             }
         case bool, float32, float64, int, int16, int32, int64, string, uint, uint16, uint32, uint64:
             valStr = fmt.Sprint(val)

--- a/transformer_test.go
+++ b/transformer_test.go
@@ -28,11 +28,11 @@ func TestTransformer(t *testing.T) {
 
 		when("Doing an ETL", func() {
 			it("Imported the input yml successfully", func() {
-				Expect(len(input)).To(Equal(6))
+				Expect(len(input)).To(Equal(8))
 			})
 
 			it("Imported the output yml successfully", func() {
-				Expect(len(output.Credentials)).To(Equal(6))
+				Expect(len(output.Credentials)).To(Equal(8))
 			})
 
 			it("Transformed the output correctly", func() {
@@ -40,7 +40,7 @@ func TestTransformer(t *testing.T) {
 				out, err := Transform("/foo", file)
 
 				Expect(err).To(BeNil())
-				Expect(len(out.Credentials)).To(Equal(6))
+				Expect(len(out.Credentials)).To(Equal(8))
 			})
 
 			it("Failed to transform bad input", func() {


### PR DESCRIPTION
This change adds support for maps which includes the sub-types
of certificates and rsa keys. It is not general purpose map
support. Since this change will also add a "guess" of the data
type rather than just stating "value" a note about double-checking
the output is added.

Part of the code has a bit of a hack. Since the format of the input
can vary widely we use a poor-man's union by allowing that an Importable
can contain either a value directly as a string or a map. The YAML
library will not allow us to use the name 'value' for the same field,
even though only one would appear at a time. This means that we have to
set a different element name for maps - and then change the name before
printing the results. This is a bit hacky but is significantly simpler
than hand-writing our own marshal/unmarshal code which would then have
to be maintained and tested.